### PR TITLE
Use String representation of project version

### DIFF
--- a/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
+++ b/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/GrailsGradlePlugin.groovy
@@ -245,7 +245,7 @@ class GrailsGradlePlugin extends GroovyPlugin {
         def buildPropertiesTask = project.tasks.create("buildProperties")
         def buildPropertiesContents = ['grails.env': Environment.isSystemSet() ? Environment.current.name : Environment.PRODUCTION.name,
                                         'info.app.name': project.name,
-                                        'info.app.version':  project.version,
+                                        'info.app.version':  project.version.toString(),
                                         'info.app.grailsVersion': project.properties.get('grailsVersion')]
 
         buildPropertiesTask.inputs.properties(buildPropertiesContents)


### PR DESCRIPTION
Gradle's documentation says that `project.version` can be an `Object`.
Gradle will evaluate `toString()` on whatever it gets and use it.

Grails, however tried to put the original object into the map called
`buildPropertiesContents`. This tries to serialize the version.

When the version is a string, it works just fine. However when using
an object that does not implement `Serializable`, it causes the gradle
build to fail with this exception

```
org.gradle.api.GradleException: Unable to store input properties for task ':grooves-example-grails-mongo:buildProperties'. Property 'info.app.version' with value '0.0.3-dev.21+1a03a65' cannot be serialized.
        at org.gradle.api.internal.changedetection.rules.InputPropertiesTaskStateChanges.<init>(InputPropertiesTaskStateChanges.java:63)
        at org.gradle.api.internal.changedetection.rules.TaskUpToDateState.<init>(TaskUpToDateState.java:50)
        at org.gradle.api.internal.changedetection.changes.DefaultTaskArtifactStateRepository$TaskArtifactStateImpl.getStates(DefaultTaskArtifactStateRepository.java:170)
        at org.gradle.api.internal.changedetection.changes.DefaultTaskArtifactStateRepository$TaskArtifactStateImpl.calculateCacheKey(DefaultTaskArtifactStateRepository.java:128)
        at org.gradle.api.internal.tasks.execution.ResolveBuildCacheKeyExecuter.execute(ResolveBuildCacheKeyExecuter.java:43)
        at org.gradle.api.internal.tasks.execution.ValidatingTaskExecuter.execute(ValidatingTaskExecuter.java:58)
        at org.gradle.api.internal.tasks.execution.SkipEmptySourceFilesTaskExecuter.execute(SkipEmptySourceFilesTaskExecuter.java:88)
        at org.gradle.api.internal.tasks.execution.ResolveTaskArtifactStateTaskExecuter.execute(ResolveTaskArtifactStateTaskExecuter.java:46)
        at org.gradle.api.internal.tasks.execution.SkipTaskWithNoActionsExecuter.execute(SkipTaskWithNoActionsExecuter.java:51)
        at org.gradle.api.internal.tasks.execution.SkipOnlyIfTaskExecuter.execute(SkipOnlyIfTaskExecuter.java:54)
        at org.gradle.api.internal.tasks.execution.ResolveTaskOutputCachingStateExecuter.execute(ResolveTaskOutputCachingStateExecuter.java:47)
        at org.gradle.api.internal.tasks.execution.ExecuteAtMostOnceTaskExecuter.execute(ExecuteAtMostOnceTaskExecuter.java:43)
        at org.gradle.api.internal.tasks.execution.CatchExceptionTaskExecuter.execute(CatchExceptionTaskExecuter.java:34)
        at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:236)
        at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker$1.execute(DefaultTaskGraphExecuter.java:228)
        at org.gradle.internal.Transformers$4.transform(Transformers.java:169)
        at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:106)
        at org.gradle.internal.progress.DefaultBuildOperationExecutor.run(DefaultBuildOperationExecutor.java:61)
        at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker.execute(DefaultTaskGraphExecuter.java:228)
        at org.gradle.execution.taskgraph.DefaultTaskGraphExecuter$EventFiringTaskWorker.execute(DefaultTaskGraphExecuter.java:215)
        at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.processTask(AbstractTaskPlanExecutor.java:77)
        at org.gradle.execution.taskgraph.AbstractTaskPlanExecutor$TaskExecutorWorker.run(AbstractTaskPlanExecutor.java:58)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
        at org.gradle.internal.concurrent.StoppableExecutorImpl$1.run(StoppableExecutorImpl.java:46)
Caused by: org.gradle.api.UncheckedIOException: java.io.NotSerializableException: org.ajoberstar.gradle.git.release.base.ReleasePluginExtension$DelayedVersion
        at org.gradle.api.internal.changedetection.state.ValueSnapshotter.serialize(ValueSnapshotter.java:126)
        at org.gradle.api.internal.changedetection.state.ValueSnapshotter.snapshot(ValueSnapshotter.java:115)
        at org.gradle.api.internal.changedetection.state.AbstractScalarValueSnapshot.snapshot(AbstractScalarValueSnapshot.java:40)
        at org.gradle.api.internal.changedetection.state.ValueSnapshotter.snapshot(ValueSnapshotter.java:136)
        at org.gradle.api.internal.changedetection.rules.InputPropertiesTaskStateChanges.<init>(InputPropertiesTaskStateChanges.java:54)
        ... 23 more
Caused by: java.io.NotSerializableException: org.ajoberstar.gradle.git.release.base.ReleasePluginExtension$DelayedVersion
        at org.gradle.api.internal.changedetection.state.ValueSnapshotter.serialize(ValueSnapshotter.java:123)
        ... 27 more
```

The reason for this, in my case was, I was using the gradle-git
plugin.

However, since Grails only passes this as something for applications
to use for informational purposes, it probably makes sense for Grails
to do exactly the same thing as Gradle, and invoke `toString()` on the
version.